### PR TITLE
Add typescript typings, fix iOS Safari bug

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,13 @@
+import { Component, CSSProperties, ReactNode } from "react"
+
+interface FullscreenProps {
+  enabled: boolean
+  onChange?: (enabled: boolean) => any
+  className?: string
+  style?: CSSProperties
+  children?: ReactNode
+}
+
+declare class FullScreen extends Component<FullscreenProps> {}
+
+export default FullScreen

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "build": "babel ./src/ --out-dir ./dist"
   },
   "main": "dist/index.js",
+  "typings": "./index.d.ts",
   "dependencies": {
+    "@types/react": "*",
     "fscreen": "^1.0.1",
     "prop-types": "^15.5.10",
     "react": "^15.6.1"

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -7,6 +7,7 @@ class FullScreen extends Component {
     children: PropTypes.node.isRequired,
     enabled: PropTypes.bool.isRequired,
     onChange: PropTypes.func,
+    className: PropTypes.string,
   };
 
   static defaultProps = {
@@ -49,17 +50,21 @@ class FullScreen extends Component {
   }
 
   enterFullScreen() {
-    fscreen.requestFullscreen(this.node);
+    if (fscreen.fullscreenEnabled) {
+      fscreen.requestFullscreen(this.node);
+    }
   }
 
   leaveFullScreen() {
-    fscreen.exitFullscreen();
+    if (fscreen.fullscreenEnabled) {
+      fscreen.exitFullscreen();
+    }
   }
 
   render() {
     return (
       <div
-        className="FullScreen"
+        className={this.props.className}
         ref={node => (this.node = node)}
         style={{ height: "100%", width: "100%" }}
       >

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -66,7 +66,6 @@ class FullScreen extends Component {
       <div
         className={this.props.className}
         ref={node => (this.node = node)}
-        style={{ height: "100%", width: "100%" }}
       >
         {this.props.children}
       </div>


### PR DESCRIPTION
Previously, iOS Safari threw an error when requesting fullscreen access because it does not support the fullscreen API. Now, the fullscreen request is not passed to fscreen anymore if the API is not available.

Even if the fullscreen API is not available, the parent component will still be notified of fullscreen events using `onChange` so that fallback style changes can be triggered graciously.

Furthermore, a Typescript definition file was added.