### PR TITLE
Export the FullScreenHandle and FullScreenProps type definitions.

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,18 @@
 import React, { useCallback, useState, useRef, useEffect } from 'react'
 import fscreen from 'fscreen'
 
+export interface FullScreenHandle {
+  active: boolean
+  enter: () => void
+  exit: () => void
+  node: React.MutableRefObject<HTMLDivElement | null>
+}
+
+export interface FullScreenProps {
+  handle: FullScreenHandle
+  onChange?: (state: boolean, handle: FullScreenHandle) => void
+}
+
 export function useFullScreenHandle(): FullScreenHandle {
   const [active, setActive] = useState<boolean>(false)
   const node = useRef<HTMLDivElement | null>(null)

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -18,15 +18,3 @@ declare module '*.svg' {
 }
 
 declare module 'fscreen'
-
-interface FullScreenHandle {
-  active: boolean
-  enter: () => void
-  exit: () => void
-  node: React.MutableRefObject<HTMLDivElement | null>
-}
-
-interface FullScreenProps {
-  handle: FullScreenHandle
-  onChange?: (state: boolean, handle: FullScreenHandle) => void
-}


### PR DESCRIPTION
## What is This

This pull request brings types of the `FullScreenHandle` and the `FullScreenProps` for developers who use this library.

## Details

In the current latest version of this library, only the `FullScreen` and the `useFullScreenHandle` has been exported. However, the dependent interfaces (the `FullScreenHandle` and the `FullScreenProps`) have not been exported.

When I use the latest version of this library in the IntelliJ IDEA, the result type of the `useFullScreenHandle()` function can't be recognized because any type definitions are not provided. As the result, my IntelliJ IDEA can't provide any candidate functions.

![Screenshot_20200720_181915](https://user-images.githubusercontent.com/261787/87924529-fd8f2a00-cab9-11ea-822b-03680b2e8231.png)

By providing type definitions,  we can get the functions candidates as like the following:

![Screenshot_20200720_185403](https://user-images.githubusercontent.com/261787/87924833-670f3880-caba-11ea-98f0-0269fb10f9ae.png)

I want to export the two interface definitions (the `FullScreenHandle` and the `FullScreenProps`) by moving the definitions from the `typings.d.ts` from `index.tsx`.