### PR TITLE
Pass along className to allow additional styling on Fullscreen wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ interface FullScreenProps {
 
   onChange?: (state: boolean, handle: FullScreenHandle) => void;
   // Optional callback that gets called when this screen changes state.
+  
+  className?: string;
+  // Optional prop allowing you to apply a custom class name to the FullScreen container
 }
 ```
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,6 +11,7 @@ export interface FullScreenHandle {
 export interface FullScreenProps {
   handle: FullScreenHandle;
   onChange?: (state: boolean, handle: FullScreenHandle) => void;
+  className?: string;
 }
 
 export function useFullScreenHandle(): FullScreenHandle {
@@ -54,6 +55,7 @@ export const FullScreen: React.FC<FullScreenProps> = ({
   handle,
   onChange,
   children,
+  className,
 }) => {
   const classNames = ['fullscreen'];
   if (handle.active) {
@@ -68,7 +70,7 @@ export const FullScreen: React.FC<FullScreenProps> = ({
 
   return (
     <div
-      className={classNames.join(' ')}
+      className={[className, ...classNames].join(' ')}
       ref={handle.node}
       style={handle.active ? { height: '100%', width: '100%' } : undefined}
     >


### PR DESCRIPTION
## I'm submitting a...

<!-- Place an X in one of the following: -->

- [ ] Bug Fix
- [ ] Hot Fix
- [x] Feature
- [ ] Other (Refactoring, Added tests, Documentation, ...)

## Is this a breaking change?

- [ ] Yes
- [x] No
- [ ] Unsure

## Did you write tests?

- [ ] Yes
- [x] No

#### Feature

This change adds an optional `className` prop that can used to pass additional class names to FullScreen's wrapping `<div>`.